### PR TITLE
Allow absolute paths

### DIFF
--- a/openmanager/index.php
+++ b/openmanager/index.php
@@ -1,9 +1,11 @@
 <?php
+    //echo $_GET['d'];
 	include "php/functions.php";
 	
 	$mediatype = "";
 	$uploadfolderset = false;
 	$subfoldersset = false;
+    	$absolute = false;
 	
 	if(isset($_GET['type']))
 	{
@@ -13,6 +15,7 @@
 	if(isset($_GET['d']))
 	{
 		$uploadfolder = $_GET['d'];
+        	if($_GET['d'][0] == '/') $absolute = true;
 	}	
 	
 	//get files in folder
@@ -39,6 +42,8 @@
 		{	
 			$file_path = $imagepath . $file_name;
 			$thumb_file_path = $thumbimagepath . $file_name;
+            		if($absolute)  $thumb_file_path = str_replace($_SERVER['DOCUMENT_ROOT'],'',$thumb_file_path);
+
 			//if (is_file($file_path) && $file_name[0] !== '.')
 			if (is_file($file_path) && $file_name[0] !== '.')
 			{

--- a/openmanager/php/ajax.php
+++ b/openmanager/php/ajax.php
@@ -1,9 +1,19 @@
 <?php
 	include "functions.php";
-	
-	//get files in folder
-	$thumbimagepath = "../".$_GET['d']."images/thumbs/";
-	$imagepath = "../".$_GET['d']."images/";
+
+
+
+
+    $_GET['d'][0] == '/' ? $absolute = true : $absolute = false;
+
+    //get files in folder
+    if($absolute) {
+        $thumbimagepath = $_GET['d']."images/thumbs/";
+        $imagepath = $_GET['d']."images/";
+    } else {
+        $thumbimagepath = "../".$_GET['d']."images/thumbs/";
+        $imagepath = "../".$_GET['d']."images/";
+    }
 	
 	//handle a delete before
 	if(isset($_GET['del']))
@@ -38,6 +48,7 @@
 	{	
 		$file_path = $imagepath . $file_name;
 		$thumb_file_path = $thumbimagepath . $file_name;
+        if($absolute)  $thumb_file_path = str_replace($_SERVER['DOCUMENT_ROOT'],'',$thumb_file_path);
 		//if (is_file($file_path) && $file_name[0] !== '.')
 		if (is_file($file_path) && $file_name[0] !== '.')
 		{

--- a/openmanager/php/fileactions.php
+++ b/openmanager/php/fileactions.php
@@ -277,7 +277,7 @@
 
 			if (isset($scale) === true)
 			{
-					//$scale = array_filter(explode('*', $scale), 'is_numeric');
+					//$scale = array_filter(explode('*', $scale), 'is_numeric'); 
 
 					if (count($scale) >= 1)
 					{

--- a/openmanager/php/fileactions.php
+++ b/openmanager/php/fileactions.php
@@ -17,14 +17,20 @@
 	
 	function upload_file()
 	{
+        $absolute = false;
+        if($_POST['uploadfolder'][0] == '/') $absolute = true;
+
 		//get upload folder
 		$uploadfolder = "";
 		if(isset($_POST['uploadfolder']))
 		{
-			$uploadfolder = "../".$_POST['uploadfolder'];
+			if($absolute) $uploadfolder = $_POST['uploadfolder'];
+            else $uploadfolder = "../".$_POST['uploadfolder'];
+
 			$reluploadfolder = $_POST['uploadfolder'];
 		}
-				
+
+
 		if((file_exists($uploadfolder))&&($uploadfolder!=""))
 		{
 			//check the that a file has been uploaded by checking for name
@@ -38,7 +44,7 @@
 				$tname = $_FILES['userfile']['name'];
 				
 				//do some crude cleaning/sanitizing of the name (needs to be improved)
-				$name = strtr($tname, 'ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜÝàáâãäåçèéêëìíîïðòóôõöùúûüýÿ', 'AAAAAACEEEEIIIIOOOOOUUUUYaaaaaaceeeeiiiioooooouuuuyy');
+				$name = strtr($tname, 'Ã€ÃÃ‚ÃƒÃ„Ã…Ã‡ÃˆÃ‰ÃŠÃ‹ÃŒÃÃŽÃÃ’Ã“Ã”Ã•Ã–Ã™ÃšÃ›ÃœÃÃ Ã¡Ã¢Ã£Ã¤Ã¥Ã§Ã¨Ã©ÃªÃ«Ã¬Ã­Ã®Ã¯Ã°Ã²Ã³Ã´ÃµÃ¶Ã¹ÃºÃ»Ã¼Ã½Ã¿', 'AAAAAACEEEEIIIIOOOOOUUUUYaaaaaaceeeeiiiioooooouuuuyy');
 				$name = preg_replace('/\s+/', '-', $name); //remove spaces
 				
 				
@@ -59,7 +65,7 @@
 					if(!file_exists($uploadfolder.$mediafolder))
 					{
 						//if it doesn't exists try to create it
-						if(!mkdir($uploadfolder.$mediafolder, 0777))
+						if(!mkdir($uploadfolder.$mediafolder, 0755))
 						{
 							//if it can't be created return error about permissions
 							$error = array('error' => 'Please check the correct permissions are set on the upload folder');
@@ -78,7 +84,7 @@
 					if(!file_exists($uploadfolder.$imagesfolder))
 					{
 						//if it doesn't exists try to create it
-						if(!mkdir($uploadfolder.$imagesfolder, 0777))
+						if(!mkdir($uploadfolder.$imagesfolder, 0755))
 						{
 							//if it can't be created return error about permissions
 							$error = array('error' => 'Please check the correct permissions are set on the upload folder');
@@ -87,7 +93,7 @@
 						}
 						
 						//try to create subfolder for thumbnails
-						if(!mkdir($uploadfolder.$imagesfolder."thumbs/", 0777))
+						if(!mkdir($uploadfolder.$imagesfolder."thumbs/", 0755))
 						{
 							//if it can't be created return error about permissions
 							$error = array('error' => 'Please check the correct permissions are set on the upload folder');
@@ -144,6 +150,12 @@
 						$uploadinfo->destination = $reluploadfolder.$imagesfolder.$filename.".".$fileext;
 						$uploadinfo->mediatype = $mediatype;
 					}
+
+                    if($absolute) {
+                        $uploadinfo->destination = str_replace($_SERVER['DOCUMENT_ROOT'],'',$uploadinfo->destination);
+                        $uploadinfo->thumb_name = str_replace($_SERVER['DOCUMENT_ROOT'],'',$uploadinfo->thumb_name);
+                    }
+
 					echo json_encode(array($uploadinfo));
 				}
 				else

--- a/openmanager/php/functions.php
+++ b/openmanager/php/functions.php
@@ -2,13 +2,24 @@
 	//display specific page of gallery - takes a list of filenames & page number to display
 	function display_gallery_page($files_array, $pageno = 1, $prepath = "", $resultspp = 15, $display = true)
 	{
-		$pagination['resultspp'] = $resultspp; //results per page
+		$absolute = false;
+
+        $pagination['resultspp'] = $resultspp; //results per page
 		$pagination['startres'] = 1 + (($pageno-1) * $pagination['resultspp']); //start result
 		$pagination['endres'] = $pagination['startres'] + $pagination['resultspp'] - 1; //end result
 		$pagination['counter'] = 1; //file iterator
 		$pagination['totalres'] = count($files_array); //total number of files/results
 		$pagination['totalpages'] = ceil($pagination['totalres']/$pagination['resultspp']); //total number of pages based on number of results and results per page
-		
+
+
+        if($_GET['d'][0] == '/') $absolute = true;
+
+        if($absolute)   { //if path is absolute..
+            $prepath = '';
+
+        }
+
+
 		$thumbimagepath = $_GET['d']."images/thumbs/";
 		$imagepath = $_GET['d']."images/";
 		
@@ -28,6 +39,10 @@
 			$file_path = $imagepath . $file_name;
 			$rel_file_path = $relimagepath . $file_name;
 			$thumb_file_path = $thumbimagepath . $file_name;
+            if($absolute) {
+                $thumb_file_path = str_replace($_SERVER['DOCUMENT_ROOT'],'',$thumb_file_path);
+                $file_path = str_replace($_SERVER['DOCUMENT_ROOT'],'',$file_path);
+            }
 			
 			if(($pagination['counter']>=$pagination['startres'])&&($pagination['counter']<=$pagination['endres']))
 			{


### PR DESCRIPTION
hello, I had problems on my production server with relative paths - so i made some quick changes to allow absolute paths in config / tinyMce init, like this:

```
    open_manager_upload_path: '<?php echo $_SERVER['DOCUMENT_ROOT'];?>/uploads/',
```

(don't know if this is needed too - it probably is:

```
    relative_urls : false,
```

)

it's just a quinck patch, not fully tested (it works for me, so it was enough at the time)

Some refactoring might be needed. But sharing anyway is probably better than keeping it for me :)
